### PR TITLE
Document missing output history with sqlite

### DIFF
--- a/docs/tutorial_hist.rst
+++ b/docs/tutorial_hist.rst
@@ -465,7 +465,9 @@ Sqlite History Backend
 Xonsh has a second built-in history backend powered by sqlite (other than
 the JSON version mentioned all above in this tutorial). It shares the same
 functionality as the JSON version in most ways, except it currently doesn't
-support ``history diff`` and ``history replay`` actions.
+support ``history diff`` and ``history replay`` actions and does not store
+the output of commands, as the json-backend. E.g. `__xonsh__.history[-1].out`
+will always be `None`.
 
 The Sqlite history backend can provide a speed advantage in loading history
 into a just-started xonsh session. The JSON history backend may need to read


### PR DESCRIPTION
Not sure if this a known bug with the sqlite history backend or just not implemented (yet) and somebody forgot to mention it in the documentation.

Whichever, this does not work:
```
15-11:57[confus@jcgbx ~]
$ history info
backend: sqlite
sessionid: 2965636d-6679-4f21-848d-5a9ca0bf17bd
filename: /home/confus/.local/share/xonsh/xonsh-history.sqlite
session items: 0
all items: 23
gc options: (16256, 'commands')
15-11:57[confus@jcgbx ~]
$ history info
backend: sqlite
sessionid: 2965636d-6679-4f21-848d-5a9ca0bf17bd
filename: /home/confus/.local/share/xonsh/xonsh-history.sqlite
session items: 0
all items: 23
gc options: (16256, 'commands')
```
but with the json-backend it does:
```
15-11:55[confus@jcgbx ~/devel/unix/xonsh/docs]  master|✓
$ history info
backend: json
sessionid: 9187eb95-a14f-46f7-957c-3bab4aedf0eb
filename: /home/confus/.local/share/xonsh/xonsh-9187eb95-a14f-46f7-957c-3bab4aedf0eb.json
length: 18
buffersize: 100
bufferlength: 18
gc options: (16256, 'commands')
15-11:56[confus@jcgbx ~/devel/unix/xonsh/docs]  master|✓
$ print(1+1)
2
15-11:56[confus@jcgbx ~/devel/unix/xonsh/docs]  master|✓
$ __xonsh__.history[-1].out
'2\n'
```